### PR TITLE
Import latest goodies from wallabag firefox extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,18 +50,17 @@ function shaarliIt(url, title, description) {
         'post='+encodeURIComponent(url),
         'title='+encodeURIComponent(title),
         'description='+encodeURIComponent(description),
-            'source=bookmarklet'
     ];
 
     var features = [
         'height='+height,
         'width='+width,
         'centerscreen=yes',
-            'toolbar=no',
-            'menubar=no',
-                'scrollbars=no',
-                'status=no',
-                    'dialog'
+        'toolbar=no',
+        'menubar=no',
+        'scrollbars=no',
+        'status=no',
+        'dialog'
     ];
 
     var postUrl = shaarliUrl+"?"+GET.join('&');
@@ -84,7 +83,7 @@ function shaarliIt(url, title, description) {
             });
     } else {
         openDialog({
-            url: postUrl,
+            url: postUrl + 'source=bookmarklet',
             features: features.join(',')
         });
     }

--- a/locale/en.properties
+++ b/locale/en.properties
@@ -1,0 +1,3 @@
+cfg_msg_title=Shaarli configuration
+cfg_msg_text=Please configure the URL of your Shaarli.
+cfg_invalid_msg_text=Configured URL is invalid. Please fix.

--- a/locale/fr.properties
+++ b/locale/fr.properties
@@ -1,0 +1,4 @@
+
+cfg_msg_title=Configuration de Shaarli
+cfg_msg_text=Veuillez configurer l'URL de votre Shaarli.
+cfg_invalid_msg_text=L'URL configurée est invalide. Merci de la corriger.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
         "title": "Window height",
         "type": "integer",
         "value": 390
+    },
+    {
+        "name": "shaarliOpenTab",
+        "title": "Open a tab instead of a dialog window.",
+        "type": "bool",
+        "value": false
     }
   ]
 }


### PR DESCRIPTION
- ability to open a tab instead of a dialog
- open preferences window and show a notification if
  - url is not set
  - url is not valid

Includes code from Fabien SK fab@fabsk.eu. Many thanks for his
contributions!

Both projects are gpl v3, so importing the code should not be a problem.
